### PR TITLE
Fix process_stylesheet_url to handle "?body=1" appended by the asset pipeline.

### DIFF
--- a/lib/action_mailer/in_style/premailer.rb
+++ b/lib/action_mailer/in_style/premailer.rb
@@ -31,7 +31,7 @@ module ActionMailer
 
       def process_stylesheet_url(href)
         # Example stylesheet url: email-1bd4488901bfc2f2ccf4f044fc9154a6.css
-        href = href.to_s.sub(/\?[0-9a-zA-Z]+$/, '').sub(/^\/assets\//, '')
+        href = href.to_s.sub(/\?[0-9a-zA-Z]+$/, '').sub(/^\/assets\//, '').sub('?body=1', '')
 
         if href =~ /(\w+)\-(?:[0-9a-zA-Z]{32})\.([a-z]{3})/
           href = href.gsub(/(\w+)\-(?:[0-9a-zA-Z]{32})\.([a-z]{3})/, [$1,$2].join('.'))


### PR DESCRIPTION
The style sheets could not be retrieved from the asset pipeline using Rails 3.2. This fixes it for me in development env.

Thanx for this nice gem!
